### PR TITLE
Fix strings broken when exporting to CSV.

### DIFF
--- a/MSBT.cs
+++ b/MSBT.cs
@@ -781,8 +781,8 @@ namespace MsbtEditor
 					sb.AppendLine("Label,String");
 					for (int i = 0; i < TXT2.NumberOfStrings; i++)
 					{
-						ent = LBL1.Labels[i];
-						row.Add(ent.ToString());
+						ent = TXT2.Strings[i];
+						row.Add(LBL1.Labels[i].ToString());
 						row.Add("\"" + ent.ToString(FileEncoding).Replace("\"", "\"\"") + "\"");
 						sb.AppendLine(string.Join(",", row.ToArray()));
 						row.Clear();


### PR DESCRIPTION
When a file has labels, it was exporting the label name in place of the string value because the label entry was assigned to "ent". This is a quick fix that should export the Label under the Label column and the edited string under String column, as is the intended behavior.

P.S. This program works with Paper Mario: Color Splash (Wii U), which also uses the msbt format. :)